### PR TITLE
Get the cookie from the first redirect

### DIFF
--- a/netdot/Client.py
+++ b/netdot/Client.py
@@ -88,7 +88,7 @@ class Connect(object):
       response = requests.post(self.login_url, data=params, 
                               headers=self.headers)
       if response.status_code == 200:
-        self.auth_cookies = response.request.cookies
+        self.auth_cookies = response.history[0].cookies
       else:
         raise AttributeError('Invalid Credentials')
   


### PR DESCRIPTION
I'm not sure if there's something wrong with my NetDot installation or if something changed in between, but due to the redirects response.request.cookies was empty and I had to fetch it from the history.
